### PR TITLE
Exec functionality added to pldctl

### DIFF
--- a/cmd/pldrApply.go
+++ b/cmd/pldrApply.go
@@ -128,6 +128,20 @@ func parseApply(resourceDefinition string, resource json.RawMessage) error {
 			log.Debugln(response.Error)
 			log.Fatalln(response.FriendlyError)
 		}
+	case "parlay":
+		u.Path = path.Join(u.Path, apiserver.ParlayAPIPath())
+
+		// Apply the POST
+		response, err := plunderapi.ParsePlunderPost(u, c, resource)
+		if err != nil {
+			log.Fatalf("%s", err.Error())
+		}
+
+		// If an error has been returned then handle the error gracefully and terminate
+		if response.FriendlyError != "" || response.Error != "" {
+			log.Debugln(response.Error)
+			log.Fatalln(response.FriendlyError)
+		}
 	default:
 		return fmt.Errorf("Unknown resource Definition [%s]", resourceDefinition)
 

--- a/cmd/pldrCreate.go
+++ b/cmd/pldrCreate.go
@@ -27,7 +27,7 @@ func init() {
 //pldrctlCreate - is used for it's subcommands for pulling data from a plunder server
 var pldrctlCreate = &cobra.Command{
 	Use:   "create",
-	Short: "Apply a configuration to plunder",
+	Short: "Create a new configuration for plunder",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.Level(logLevel))
 

--- a/cmd/pldrDelete.go
+++ b/cmd/pldrDelete.go
@@ -27,10 +27,10 @@ var pldrctlDelete = &cobra.Command{
 		if err != nil {
 			log.Fatalf("%s", err.Error())
 		}
-		dashMac := strings.Replace(args[0], ":", "-", -1)
 		switch strings.ToLower(deleteTypeFlag) {
 		case "config":
 		case "deployment":
+			dashMac := strings.Replace(args[0], ":", "-", -1)
 
 			u.Path = path.Join(u.Path, apiserver.DeploymentAPIPath()+"/"+dashMac)
 
@@ -46,6 +46,20 @@ var pldrctlDelete = &cobra.Command{
 
 		case "deployments":
 		case "globalConfig":
+		case "logs":
+			dashAddress := strings.Replace(args[0], ":", "-", -1)
+
+			u.Path = path.Join(u.Path, apiserver.ParlayAPIPath()+"/logs/"+dashAddress)
+
+			response, err := plunderapi.ParsePlunderDelete(u, c)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			// If an error has been returned then handle the error gracefully and terminate
+			if response.FriendlyError != "" || response.Error != "" {
+				log.Debugln(response.Error)
+				log.Fatalln(response.FriendlyError)
+			}
 		default:
 			log.Fatalf("Unknown resource type [%s]", deleteTypeFlag)
 

--- a/cmd/pldrExec.go
+++ b/cmd/pldrExec.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"encoding/json"
+	"path"
+
+	"github.com/plunder-app/pldrctl/pkg/plunderapi"
+	"github.com/plunder-app/plunder/pkg/apiserver"
+	"github.com/plunder-app/plunder/pkg/parlay"
+	"github.com/plunder-app/plunder/pkg/parlay/types"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var execHost, execCommand string
+
+func init() {
+	pldrctlExec.Flags().StringVarP(&execHost, "address", "a", "", "Host to submit the execution job too")
+	pldrctlExec.Flags().StringVarP(&execCommand, "command", "c", "", "Command to submit to the remote host")
+
+}
+
+//pldrcltlDescribe - is used for it's subcommands for pulling data from a plunder server
+var pldrctlExec = &cobra.Command{
+	Use:   "exec",
+	Short: "Execute a command against a host",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+
+		if execHost == "" {
+			cmd.Help()
+			log.Fatalf("No Host was submitted")
+		}
+		if execCommand == "" {
+			cmd.Help()
+			log.Fatalf("No Command was submitted")
+		}
+
+		newDeployment := parlay.Deployment{
+			Name:     "pldrctl exec",
+			Parallel: false,
+		}
+		newDeployment.Hosts = append(newDeployment.Hosts, execHost)
+
+		action := types.Action{
+			ActionType: "command",
+			Command:    execCommand,
+			Name:       "pldrctl command",
+		}
+		newDeployment.Actions = append(newDeployment.Actions, action)
+
+		var newMap parlay.TreasureMap
+		newMap.Deployments = append(newMap.Deployments, newDeployment)
+
+		// Pass the execution data to the API endpoint
+		u, c, err := plunderapi.BuildEnvironmentFromConfig(pathFlag, urlFlag)
+		if err != nil {
+			log.Fatalf("%s", err.Error())
+		}
+
+		u.Path = path.Join(u.Path, apiserver.ParlayAPIPath())
+		b, err := json.Marshal(newMap)
+		if err != nil {
+			log.Fatalf("%s", err.Error())
+		}
+		response, err := plunderapi.ParsePlunderPost(u, c, b)
+		if err != nil {
+			log.Fatalf("%s", err.Error())
+		}
+		// If an error has been returned then handle the error gracefully and terminate
+		if response.FriendlyError != "" || response.Error != "" {
+			log.Debugln(response.Error)
+			log.Fatalln(response.FriendlyError)
+		}
+
+	},
+}

--- a/cmd/pldrctl.go
+++ b/cmd/pldrctl.go
@@ -32,6 +32,7 @@ func init() {
 	pldrctlCmd.AddCommand(pldrctlCreate)
 	pldrctlCmd.AddCommand(pldrctlDelete)
 	pldrctlCmd.AddCommand(pldrctlDescribe)
+	pldrctlCmd.AddCommand(pldrctlExec)
 	pldrctlCmd.AddCommand(pldrctlGet)
 	pldrctlCmd.AddCommand(pldrctlVersion)
 }

--- a/cmd/pldrget.go
+++ b/cmd/pldrget.go
@@ -4,23 +4,32 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+	"strings"
+	"time"
 
 	"github.com/plunder-app/pldrctl/pkg/plunderapi"
 	"github.com/plunder-app/pldrctl/pkg/ux"
 
 	"github.com/plunder-app/plunder/pkg/apiserver"
+	"github.com/plunder-app/plunder/pkg/plunderlogging"
 	"github.com/plunder-app/plunder/pkg/services"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
+var watch int
+
 func init() {
 	pldrctlGet.PersistentFlags().StringVar(&urlFlag, "url", os.Getenv("pURL"), "The Url of a plunder server")
+
+	getLogs.Flags().IntVarP(&watch, "watch", "w", 0, "Setting a watch timeout until \"completion\" or \"fail\"")
 
 	pldrctlGet.AddCommand(getBoot)
 	pldrctlGet.AddCommand(getDeployments)
 	pldrctlGet.AddCommand(getGlobal)
 	pldrctlGet.AddCommand(getConfig)
+	pldrctlGet.AddCommand(getLogs)
+
 	pldrctlGet.AddCommand(getUnLeased)
 }
 
@@ -181,6 +190,60 @@ var getGlobal = &cobra.Command{
 			err = ux.CheckOutFlag(outputFlag, NewResourceContainer("globalConfig", globalConfigJSON))
 		} else {
 			ux.GlobalFormat(deployments.GlobalServerConfig)
+		}
+	},
+}
+
+var getLogs = &cobra.Command{
+	Use:   "logs",
+	Short: "Retrieve the logs from a Parlay deployment",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		u, c, err := plunderapi.BuildEnvironmentFromConfig(pathFlag, urlFlag)
+		if err != nil {
+			log.Fatalf("%s", err.Error())
+		}
+		if len(args) != 1 {
+			log.Fatalf("An address of a remote server to retrieve the logs for is required")
+		}
+
+		dashAddress := strings.Replace(args[0], ".", "-", -1)
+
+		u.Path = path.Join(u.Path, apiserver.ParlayAPIPath()+"/logs/"+dashAddress)
+		for {
+			response, err := plunderapi.ParsePlunderGet(u, c)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+			// If an error has been returned then handle the error gracefully and terminate
+			if response.FriendlyError != "" || response.Error != "" {
+				log.Debugln(response.Error)
+				log.Fatalln(response.FriendlyError)
+			}
+
+			var logs plunderlogging.JSONLog
+
+			err = json.Unmarshal(response.Payload, &logs)
+			if err != nil {
+				log.Fatalf("%s", err.Error())
+			}
+
+			if outputFlag != "" {
+				err = ux.CheckOutFlag(outputFlag, NewResourceContainer("logs", response.Payload))
+				break
+			} else {
+				if watch == 0 {
+					ux.LogsGetFormat(logs)
+					break
+				} else {
+					ux.LogsGetFormat(logs)
+					if logs.State != "Running" {
+						break
+					}
+					// Now repeat again
+					time.Sleep(time.Duration(watch) * time.Second)
+				}
+			}
 		}
 	},
 }

--- a/pkg/ux/logs.go
+++ b/pkg/ux/logs.go
@@ -1,0 +1,38 @@
+package ux
+
+import (
+	"time"
+
+	"github.com/gookit/color"
+	"github.com/plunder-app/plunder/pkg/plunderlogging"
+)
+
+//LogsGetFormat -
+func LogsGetFormat(logs plunderlogging.JSONLog) {
+
+	color.White.Printf("Logs:\n")
+	for i := range logs.Entries {
+		color.Green.Printf("Started: ")
+		color.White.Printf("%s\t", logs.Entries[i].Created.Format(time.ANSIC))
+		color.Green.Printf("Task Name: ")
+		color.White.Printf("%s\n", logs.Entries[i].TaskName)
+		if logs.Entries[i].Entry != "" {
+			color.Green.Printf("Output:\n")
+			color.White.Printf("%s\n", logs.Entries[i].Entry)
+		}
+		if logs.Entries[i].Err != "" {
+			color.Red.Printf("Error:\n")
+			color.White.Printf("%s\n", logs.Entries[i].Err)
+		}
+	}
+	color.White.Printf("Task Status: ")
+	switch logs.State {
+	case "Completed":
+		color.Green.Printf("Completed\n")
+	case "Running":
+		color.Blue.Printf("Running\n")
+	case "Failed":
+		color.Red.Printf("Failed\n")
+	}
+
+}


### PR DESCRIPTION
`pldrctl exec` now can work against an IP (address)
`pldrctl get -t logs` can pull logs for an IP
`pldrctl delete -t logs` can delete the in-memory logs for an IP