### PR TITLE
This fix allows output from unleased nodes to be outputted in JSON/YAML

### DIFF
--- a/cmd/pldrget.go
+++ b/cmd/pldrget.go
@@ -278,6 +278,10 @@ var getUnLeased = &cobra.Command{
 			log.Fatalf("%s", err.Error())
 		}
 
-		ux.LeasesGetFormat(unleased)
+		if outputFlag != "" {
+			err = ux.CheckOutFlag(outputFlag, NewResourceContainer("unleased", response.Payload))
+		} else {
+			ux.LeasesGetFormat(unleased)
+		}
 	},
 }


### PR DESCRIPTION
This adds a `-o --output` flag to the unleased subcommand 