### PR TITLE
Adds the capability to add a ISO deployment

### DIFF
--- a/cmd/pldrApply.go
+++ b/cmd/pldrApply.go
@@ -60,13 +60,13 @@ var pldrctlApply = &cobra.Command{
 		if len(output) == 0 {
 			log.Fatalf("No data could be read")
 		}
-		resource, rawJSON, err := UnPackResourceContainer(output)
+		resource, err := UnPackResourceContainer(output)
 		if err != nil {
 			cmd.Help()
 			log.Fatalln(err)
 		}
 
-		err = parseApply(resource, rawJSON)
+		err = parseApply(resource.Definition, resource.Resource)
 		if err != nil {
 			cmd.Help()
 

--- a/cmd/pldrCreate.go
+++ b/cmd/pldrCreate.go
@@ -18,6 +18,8 @@ func init() {
 	pldrctlCreateBoot.Flags().StringVarP(&bootConfig.Kernel, "kernel", "k", "", "The path of the kernel to be booted")
 	pldrctlCreateBoot.Flags().StringVarP(&bootConfig.Initrd, "initrd", "i", "", "The path of init ramdisk to be booted")
 	pldrctlCreateBoot.Flags().StringVarP(&bootConfig.Cmdline, "cmdline", "c", "", "Additional kernel commandline flags (optional)")
+	pldrctlCreateBoot.Flags().StringVar(&bootConfig.ISOPath, "isoPath", "", "The path of an ISO to read from (optional)")
+	pldrctlCreateBoot.Flags().StringVar(&bootConfig.ISOPrefix, "isoPrefix", "", "The prefix to bind the ISO too (optional)")
 
 	pldrctlCreateDeployment.Flags().StringVarP(&createTypeFlag, "type", "t", "", "Type of resource to create")
 	pldrctlCreateDeployment.Flags().StringVarP(&deployment.MAC, "mac", "m", "", "Mac Address of the resource to create")

--- a/cmd/pldrDelete.go
+++ b/cmd/pldrDelete.go
@@ -8,13 +8,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var deleteTypeFlag string
-
 func init() {
+
+	pldrctlDelete.AddCommand(pldrctlDeleteBoot)
 	pldrctlDelete.AddCommand(pldrctlDeleteDeployment)
 	pldrctlDelete.AddCommand(pldrctlDeleteLogs)
 
-	pldrctlDelete.Flags().StringVarP(&deleteTypeFlag, "type", "t", "", "Type of resource to create")
 }
 
 func deleteOperation(url string) (resp *apiserver.Response) {
@@ -73,6 +72,23 @@ var pldrctlDeleteLogs = &cobra.Command{
 			log.Fatalf("Only argument should be an IP address to have it's logs removed")
 		}
 		resp := deleteOperation(apiserver.ParlayAPIPath() + "/logs/" + strings.Replace(args[0], ":", "-", -1))
+		if resp.FriendlyError != "" || resp.Error != "" {
+			log.Debugln(resp.Error)
+			log.Fatalln(resp.FriendlyError)
+		}
+	},
+}
+
+//pldrctlDeleteBoot - is used for it's subcommands for pulling data from a plunder server
+var pldrctlDeleteBoot = &cobra.Command{
+	Use:   "boot",
+	Short: "Delete boot configuration from Plunder",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(log.Level(logLevel))
+		if len(args) != 1 {
+			log.Fatalf("Only argument should be an IP address to have it's logs removed")
+		}
+		resp := deleteOperation(apiserver.ConfigAPIPath() + "/" + args[0])
 		if resp.FriendlyError != "" || resp.Error != "" {
 			log.Debugln(resp.Error)
 			log.Fatalln(resp.FriendlyError)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,31 +7,33 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-type resourceContainer struct {
+// ResourceContainer is a container of a plunder resource, allowing it's definition to define it
+type ResourceContainer struct {
 	Definition string          `json:"definition"`
 	Resource   json.RawMessage `json:"resource"`
 }
 
-func NewResourceContainer(containerDefinition string, resource json.RawMessage) *resourceContainer {
+// NewResourceContainer - will create a wrapper container for a particular pludner resource
+func NewResourceContainer(containerDefinition string, resource json.RawMessage) *ResourceContainer {
 	if containerDefinition == "" {
 		return nil
 	}
 
-	return &resourceContainer{
+	return &ResourceContainer{
 		Definition: containerDefinition,
 		Resource:   resource,
 	}
 }
 
-func UnPackResourceContainer(b []byte) (containerDefinition string, resource json.RawMessage, err error) {
+// UnPackResourceContainer will take raw data, determine if it's yaml or json and then return it as
+func UnPackResourceContainer(b []byte) (container *ResourceContainer, err error) {
 
-	var container resourceContainer
 	jsonBytes, err := yaml.YAMLToJSON(b)
 	if err == nil {
 		// If there were no errors then the YAML => JSON was successful, no attempt to unmarshall
 		err = json.Unmarshal(jsonBytes, &container)
 		if err != nil {
-			return "", nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
+			return nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
 		}
 
 	} else {
@@ -39,8 +41,8 @@ func UnPackResourceContainer(b []byte) (containerDefinition string, resource jso
 		// Attempt to parse it as JSON
 		err = json.Unmarshal(b, &container)
 		if err != nil {
-			return "", nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
+			return nil, fmt.Errorf("Unable to parse configuration as either yaml or json")
 		}
 	}
-	return container.Definition, container.Resource, nil
+	return container, nil
 }


### PR DESCRIPTION
This adds the capability to manage boot configurations in plunder:

This will delete the existing pressed boot config
```
pldrctl delete boot preseed
```

This will add the capability to map directly to content in an iso without mounting it.
```
pldrctl create boot -n preseed \
-i ubuntu/install/netboot/ubuntu-installer/amd64/initrd.gz  \
-k ubuntu/install/netboot/ubuntu-installer/amd64/linux \
--isoPath "/mnt/Products/Operating Systems/Ubuntu/ubuntu-16.04.5-server-amd64.iso" \
--isoPrefix ubuntu 
```

