### PR TITLE
Fixes to the logging API call

### DIFF
--- a/cmd/pldrDelete.go
+++ b/cmd/pldrDelete.go
@@ -94,7 +94,7 @@ var pldrctlDeleteLogs = &cobra.Command{
 			log.Fatalf("%s", err.Error())
 		}
 
-		ep, resp := apiserver.FindFunctionEndpoint(u, c, "parlayLogs", http.MethodDelete)
+		ep, resp := apiserver.FindFunctionEndpoint(u, c, "parlayLog", http.MethodDelete)
 		if resp.Error != "" {
 			log.Debug(resp.Error)
 			log.Fatalf(resp.FriendlyError)

--- a/pkg/ux/dhcp.go
+++ b/pkg/ux/dhcp.go
@@ -33,8 +33,8 @@ func LeasesGetFormat(leases []services.Lease, noColour bool) {
 		}
 		// Build output template
 		fmt.Fprintf(w, format,
-			leases[i].Nic,                                       // Mac Address
-			oui.LookupMacVendor(leases[i].Nic),                  // Vendor
+			leases[i].MAC,                                       // Mac Address
+			oui.LookupMacVendor(leases[i].MAC),                  // Vendor
 			leases[i].Expiry.Format("Mon Jan _2 15:04:05 2006"), // Time Added
 			time.Since(leases[i].Expiry).Truncate(time.Second))  // Time last seen
 	}


### PR DESCRIPTION
The [delete] verb was being called agains `plunderLog` not `plunderLogs`, also fixes an import variable name change.